### PR TITLE
Fix openURL on iOS

### DIFF
--- a/packages/use-contractkit/src/dappkit-wallet/linking.ts
+++ b/packages/use-contractkit/src/dappkit-wallet/linking.ts
@@ -20,39 +20,7 @@ class Linking {
   }
 
   openURL(url: string) {
-    let ua = navigator.userAgent.toLowerCase();
-    let isAndroid = ua.indexOf('android') > -1; // android check
-    let isIphone = ua.indexOf('iphone') > -1; // ios check
-
-    if (isIphone == true) {
-      let app = {
-        launchApp: function () {
-          setTimeout(function () {
-            window.location.href =
-              'https://itunes.apple.com/us/app/appname/appid';
-          }, 25);
-          window.location.href = url; //which page to open(now from mobile, check its authorization)
-        },
-        openWebApp: function () {
-          window.location.href =
-            'https://itunes.apple.com/us/app/appname/appid';
-        },
-      };
-      app.launchApp();
-    } else if (isAndroid == true) {
-      let app = {
-        launchApp: function () {
-          window.open(url);
-        },
-        // openWebApp: function () {
-        //   window.location.href =
-        //     'https://play.google.com/store/apps/details?id=packagename';
-        // },
-      };
-      app.launchApp();
-    } else {
-      //navigate to website url
-    }
+    window.location.href = url
   }
 }
 


### PR DESCRIPTION
Short term fix, closes celo-org/celo-monorepo#7486 until we can move this -> `dappkit-web` (after [this PR](https://github.com/celo-org/celo-monorepo/pull/7484))
- timeout + redirect fix for detecting if app is installed does not work in newer versions of iOS (always redirects to app store regardless of whether Valora is installed or not)
- simple fix should work on iOS + android